### PR TITLE
Compile assembly into ELF-format

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -92,6 +92,10 @@ fn build_nasm() {
         flags.push("-g");
     }
 
+    if cfg!(target_os = "linux") {
+        flags.push("-DELF");
+    }
+
     let x86_64 = [
         "vendor/simd/jfdctflt-sse-64.asm", "vendor/simd/jccolor-sse2-64.asm", "vendor/simd/jcgray-sse2-64.asm",
         "vendor/simd/jchuff-sse2-64.asm", "vendor/simd/jcsample-sse2-64.asm", "vendor/simd/jdcolor-sse2-64.asm",


### PR DESCRIPTION
Linking this crate fails without `-DELF` flag. Without the flag symbols in compiled `.o` files are prefixed with an underscore, thus linker cannot find them.

Running `cargo test` without `-DELF` flag printed following error:
```
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-L" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "/home/user/mozjpeg-sys/target/debug/deps/mozjpeg_sys-b38d9910dcd21bea.0.o" "-o" "/home/user/mozjpeg-sys/target/debug/deps/mozjpeg_sys-b38d9910dcd21bea" "/home/user/mozjpeg-sys/target/debug/deps/mozjpeg_sys-b38d9910dcd21bea.crate.allocator.o" "-Wl,--gc-sections" "-pie" "-nodefaultlibs" "-L" "/home/user/mozjpeg-sys/target/debug/deps" "-L" "/home/user/mozjpeg-sys/target/debug/build/mozjpeg-sys-04e2cab2cecfc6eb/out" "-L" "/home/user/mozjpeg-sys/target/debug/build/mozjpeg-sys-04e2cab2cecfc6eb/out" "-L" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "-Wl,--whole-archive" "-l" "mozjpegsimd" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "-l" "mozjpeg" "-Wl,--no-whole-archive" "/home/user/mozjpeg-sys/target/debug/deps/liblibc-5920752a5339284e.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libtest-30d4d638be038598.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libterm-359c3de19d4def40.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgetopts-c58b62d995849f6d.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-29fb1fb52cf57377.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-9cbadc6554202be9.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc_jemalloc-42efcbbdeb607d44.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-618c266cf9124966.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc_system-3c10208cdd7e61cb.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-16f3b02b9a976b94.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-bc70b4efeaeb398c.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_unicode-a0ad42dc8f5856aa.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librand-32f648f7f7567c6c.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-21491ce3d14f1ef2.rlib" "/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-b9713bd7f605c0b2.rlib" "-Wl,-Bdynamic" "-l" "util" "-l" "dl" "-l" "rt" "-l" "pthread" "-l" "pthread" "-l" "gcc_s" "-l" "c" "-l" "m" "-l" "rt" "-l" "pthread" "-l" "util"
  = note: /home/user/mozjpeg-sys/target/debug/deps/mozjpeg_sys-b38d9910dcd21bea.0.o: In function `mozjpeg_sys::simd_works_sse2':
          /home/user/mozjpeg-sys/src/lib.rs:734: undefined reference to `jsimd_fdct_ifast_sse2'
          /home/user/mozjpeg-sys/target/debug/build/mozjpeg-sys-04e2cab2cecfc6eb/out/libmozjpeg.a(jsimd_x86_64.o): In function `jsimd_can_rgb_ycc':
          /home/user/mozjpeg-sys/vendor/simd/jsimd_x86_64.c:74: undefined reference to `jconst_rgb_ycc_convert_sse2'
          /home/user/mozjpeg-sys/target/debug/build/mozjpeg-sys-04e2cab2cecfc6eb/out/libmozjpeg.a(jsimd_x86_64.o): In function `jsimd_can_fdct_ifast':
          /home/user/mozjpeg-sys/vendor/simd/jsimd_x86_64.c:609: undefined reference to `jconst_fdct_ifast_sse2'
          collect2: error: ld returned 1 exit status
          

error: aborting due to previous error
```